### PR TITLE
read-config is now fixed and tested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cache
 DS_Store
 ./generate-template/tmp/**/*
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cache
 DS_Store
 ./generate-template/tmp/**/*
 *.swp
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# Not sure if that's a appropriate, but since nose is pretty much the standard
+# in python I guessed it to be a good choice.
+test:
+	@nosetests -s -v tests/

--- a/generate-template/bin/util/read-config
+++ b/generate-template/bin/util/read-config
@@ -3,8 +3,11 @@ import os, sys
 from xml.dom.minidom import parse
 
 class ConfigReader:
-    def __init__(self):
-        self.config = os.path.join(os.curdir, 'www', 'config.xml')
+    def __init__(self, config_path=None):
+        if not config_path:
+            config_path = os.path.join(os.curdir, 'www', 'config.xml')
+
+        self.config = config_path
         self.parsed = parse(self.config)
         self.appid = self.parsed.firstChild.attributes['id'].value
         self.version = self.parsed.firstChild.attributes['version'].value
@@ -15,7 +18,12 @@ class ConfigReader:
         # create a list of tuples (icon_path, icon_width)
         for index, item in enumerate(tmp_icons):
             src = item.attributes.get('src', None)
-            width = int(item.attributes.get('width', 0))
+            if src:
+                src = src.value
+
+            width = item.attributes.get('width', 0)
+            if width:
+                width = int(width.value)
 
             # shouldn't add icons that fail to provide src attribute
             if src:
@@ -33,7 +41,10 @@ class ConfigReader:
         self.icons = sorted(self.icons, comparer)
 
 if __name__ == "__main__":
-    conf = ConfigReader()
+    path = None
+    if len(sys.argv) > 2:
+        path = sys.argv[2]
+    conf = ConfigReader(path)
     # parsing out the id (com.phonegap.whatever)
     if sys.argv[1] == 'id':
         print conf.appid

--- a/generate-template/bin/util/read-config
+++ b/generate-template/bin/util/read-config
@@ -14,7 +14,13 @@ class ConfigReader:
         tmp_icons = self.parsed.getElementsByTagName('icon')
         # create a list of tuples (icon_path, icon_width)
         for index, item in enumerate(tmp_icons):
-            self.icons.append((item.attributes['src'].value, int(item.attributes['width'].value)))
+            src = item.attributes.get('src', None)
+            width = int(item.attributes.get('width', 0))
+
+            # shouldn't add icons that fail to provide src attribute
+            if src:
+                self.icons.append((src, int(width)))
+
         # sort largest icon to smallest
         def comparer(a, b):
             if a[1] > b[1]:

--- a/tests/config.xml
+++ b/tests/config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<widget xmlns="http://www.w3.org/ns/widgets" 
+        xmlns:pg="http://phonegap.com/ns/1.0" 
+        id="com.phonegap.vanilla"
+        version="0.0.0">
+
+	<name>PhoneGap Vanilla</name>
+	<description>Vanilla generated app.</description>
+	<author href="http://westcoastlogic.com" email="brian@westcoastlogic.com">@brianleroux</author>
+    <icon src="img/icon-57.png" width="57" height="57" />
+    <icon src="img/icon-72.png" width="72" height="72" />
+    <icon src="img/icon-114.png" width="114" height="114" />
+
+</widget>

--- a/tests/test_read_config.py
+++ b/tests/test_read_config.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from os.path import abspath, join, dirname
+import commands
+
+read_config_path = abspath(join(dirname(__file__), '../generate-template/bin/util/read-config'))
+read_config = lambda option: commands.getoutput('%s %s tests/config.xml' % (read_config_path, option))
+
+tests = {
+    'id': 'com.phonegap.vanilla',
+    'version': '0.0.0',
+    'name': 'PhoneGap Vanilla',
+    'small-icon': './www/img/icon-57.png',
+    'medium-icon': './www/img/icon-72.png',
+    'large-icon': './www/img/icon-114.png'
+}
+
+def test_configurations():
+    for key, value in tests.iteritems():
+        yield verify_configuration, key, value
+
+def verify_configuration(configuration, expected):
+    config_value = read_config(configuration)
+
+    assert config_value == expected, config_value
+


### PR DESCRIPTION
Fixed the way read-config reads attributes to check that they actually exist before adding the icon.

Also added tests to it, just install nose - pip intall nose or easy_install nose and run it with make in the root folder.
